### PR TITLE
Max jobs for specified characters (citizenids)

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -4,6 +4,10 @@ Config = Config or {}
 Config.Side = "right"
 
 Config.MaxJobs = 3
+Config.CharacterMaxJobs = {
+	-- ["IZK73414"] = 5,
+}
+
 Config.IgnoredJobs = {
 	["unemployed"] = true,
 }

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -198,7 +198,7 @@ RegisterNetEvent('QBCore:Server:OnJobUpdate', function(source, newJob)
         amount = amount + 1
     end
 
-    local maxJobs = Config.MaxJobs
+    local maxJobs = Config.CharacterMaxJobs[Player.PlayerData.citizenid] or Config.MaxJobs
     if QBCore.Functions.HasPermission(source, "admin") then
         maxJobs = math.huge
     end


### PR DESCRIPTION
Allows for people to specify certain characters to have access to a specified number of jobs. 