### PR TITLE
feat: add `UpdateJobRank` export + other misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ A script designed with a sleek and modern design for being able to display your 
     exports["ps-multijob"]:AddJob("citizenid here", "police", 0)
     ```
 
+* UpdateJobRank(citizenid, job, grade)
+    Example usage:
+
+    ```lua
+    exports["ps-multijob"]:UpdateJobRank("citizenid here", "police", 3)
+    ```
+
 * RemoveJob(citizenid, job)
 
     Example usage:

--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -67,7 +67,7 @@ RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
     })
 end)
 
-RegisterCommand("jobmenu", OpenUI)
+RegisterCommand("jobmenu", OpenUI, false)
 
 RegisterKeyMapping('jobmenu', "Show Job Management", "keyboard", "J")
 

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -129,13 +129,13 @@ local function RemoveJob(citizenid, job)
 end
 exports("RemoveJob", RemoveJob)
 
-QBCore.Commands.Add('removejob', 'Remove Multi Job (Admin Only)', { { name = 'id', help = 'ID of player' }, { name = 'job', help = 'Job Name' }, { name = 'grade', help = 'Job Grade' } }, false, function(source, args)
+QBCore.Commands.Add('removejob', 'Remove Multi Job (Admin Only)', { { name = 'id', help = 'ID of player' }, { name = 'job', help = 'Job Name' } }, false, function(source, args)
     local source = source
     if source ~= 0 then
         if args[1] then
             local Player = QBCore.Functions.GetPlayer(tonumber(args[1]))
             if Player then
-                if args[2]and args[3] then
+                if args[2] then
                     RemoveJob(Player.PlayerData.citizenid, args[2])
                 else
                     TriggerClientEvent("QBCore:Notify", source, "Wrong usage!")

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -42,6 +42,14 @@ end
 exports("AddJob", AddJob)
 
 local function UpdatePlayerJob(Player, job, grade)
+    if type(Player) == "string" then
+        Player = QBCore.Functions.GetOfflinePlayerByCitizenId(Player)
+    end
+
+    if Player == nil then
+        return
+    end
+
     if Player.PlayerData.source ~= nil then
         Player.Functions.SetJob(job,grade)
     else -- player is offline
@@ -70,6 +78,7 @@ local function UpdatePlayerJob(Player, job, grade)
         })
     end
 end
+exports("UpdatePlayerJob", UpdatePlayerJob)
 
 local function RemoveJob(citizenid, job)
     local Player = QBCore.Functions.GetPlayerByCitizenId(citizenid)

--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -47,13 +47,13 @@ local function UpdatePlayerJob(Player, job, grade)
     else -- player is offline
         local sharedJobData = QBCore.Shared.Jobs[job]
         if sharedJobData == nil then return end
-    
+
         local sharedGradeData = sharedJobData.grades[grade]
         if sharedGradeData == nil then return end
-    
+
         local isBoss = false
         if sharedGradeData.isboss then isBoss = true end
-    
+
         MySQL.update.await("update players set job = @jobData where citizenid = @citizenid", {
             jobData = json.encode({
                 label = sharedJobData.label,


### PR DESCRIPTION
This PR aims to change the following:
- Add an export for updating the job rank
- Fixed issues with `/removejob` command requiring non-needed args

I also went ahead and fixed some Lua warnings, hence the change on line 219, and so on.

Please note:
I've yet to test this in-game, so perhaps that should be done before merging this. But I see no reason why it wouldn't work.